### PR TITLE
make find_stream_by_name only return streams

### DIFF
--- a/officeparser.py
+++ b/officeparser.py
@@ -281,7 +281,7 @@ class CompoundBinaryFile:
 
     def find_stream_by_name(self, name):
         for d in self.directory:
-            if d.name == name:
+            if d.name == name and d._mse == STGTY_STREAM:
                 return d
         return None
 


### PR DESCRIPTION
This can be a problem when extracting macros from xls files written by apache poi, because it may insert a storage into the directory before the equally named stream containing the VB form