### PR TITLE
Python 3 compatibility

### DIFF
--- a/officeparser.py
+++ b/officeparser.py
@@ -223,7 +223,7 @@ class CompoundBinaryFile:
             data = BytesIO(self.read_chain(self.header._sectMiniFatStart))
             while True:
                 chunk = data.read(self.sector_size)
-                if chunk == '':
+                if len(chunk) == 0:
                     break
                 if len(chunk) != self.sector_size:
                     logging.warning("encountered EOF while parsing minifat")

--- a/officeparser.py
+++ b/officeparser.py
@@ -196,14 +196,14 @@ class CompoundBinaryFile:
             if len(data) != self.sector_size:
                 logging.error('broken FAT (invalid sector size {0} != {1})'.format(len(data), self.sector_size))
             else:
-                for value in unpack('<{0}L'.format(self.sector_size / 4), data):
+                for value in unpack('<{0}L'.format(self.sector_size // 4), data):
                     self.fat.append(value)
 
         # get the list of directory sectors
         self.directory = []
         buffer = self.read_chain(self.header._sectDirStart)
         directory_index = 0
-        for chunk in unpack("128s" * (len(buffer) / 128), buffer):
+        for chunk in unpack("128s" * (len(buffer) // 128), buffer):
             self.directory.append(Directory(chunk, directory_index))
             directory_index += 1
 
@@ -228,7 +228,7 @@ class CompoundBinaryFile:
                 if len(chunk) != self.sector_size:
                     logging.warning("encountered EOF while parsing minifat")
                     continue
-                for value in unpack('<{0}L'.format(self.sector_size / 4), chunk):
+                for value in unpack('<{0}L'.format(self.sector_size // 4), chunk):
                     self.minifat.append(value)
 
     def read_sector(self, sector):

--- a/officeparser.py
+++ b/officeparser.py
@@ -685,20 +685,20 @@ def _main():
     # dump options
     #
     if options.dump_sector:
-        sys.stdout.write(ofdoc.read_sector(options.dump_sector))
+        os.write(sys.stdout.fileno(), ofdoc.read_sector(options.dump_sector))
         sys.exit(0)
 
     if options.dump_ministream:
-        sys.stdout.write(ofdoc.ministream)
+        os.write(sys.stdout.fileno(), (ofdoc.ministream))
         sys.exit(0)
 
     if options.dump_stream:
-        sys.stdout.write(ofdoc.get_stream(options.dump_stream))
+        os.write(sys.stdout.fileno(), (ofdoc.get_stream(options.dump_stream)))
         sys.exit(0)
 
     if options.dump_stream_by_name:
         d = ofdoc.find_stream_by_name(options.dump_stream_by_name)
-        sys.stdout.write(ofdoc.get_stream(d.index))
+        os.write(sys.stdout.fileno(), (ofdoc.get_stream(d.index)))
         sys.exit(0)
 
     #

--- a/officeparser.py
+++ b/officeparser.py
@@ -28,6 +28,8 @@ FORM_EXTENSION = "frm"
 
 BINFILE_NAME = "/vbaProject.bin"
 
+PY3 = sys.version_info[0] == 3
+
 def fat_value_to_str(value):
     if value == DIFSECT:
         return '0xFFFFFFFC (DIF)'
@@ -402,7 +404,12 @@ class Directory:
         self._ab = self.directory[0]
         self._cb = self.directory[1]
         # convert wide chars into ASCII
-        self.name = ''.join([x for x in self._ab[0:self._cb] if ord(x) != 0])
+        if PY3:
+            # In Python 3 we have numbers we need to convert to chars
+            self.name = ''.join([chr(x) for x in self._ab[0:self._cb] if x != 0])
+        else:
+            # In Python 2 we have chars we need to convert to numbers to check them
+            self.name = ''.join([x for x in self._ab[0:self._cb] if ord(x) != 0])
         self._mse = self.directory[2]
         self._bflags = self.directory[3]
         self._sidLeftSib = self.directory[4]

--- a/officeparser.py
+++ b/officeparser.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 import sys
 from struct import unpack
 from optparse import OptionParser
-from cStringIO import StringIO
+from io import BytesIO
 import logging
 import re
 import os
@@ -218,7 +218,7 @@ class CompoundBinaryFile:
             # chain in the Fat, with the beginning of the chain stored in the
             # header.
 
-            data = StringIO(self.read_chain(self.header._sectMiniFatStart))
+            data = BytesIO(self.read_chain(self.header._sectMiniFatStart))
             while True:
                 chunk = data.read(self.sector_size)
                 if chunk == '':
@@ -249,7 +249,7 @@ class CompoundBinaryFile:
         """Returns the entire contents of a chain starting at the given sector."""
         sector = start
         check = [ sector ] # keep a list of sectors we've already read
-        buffer = StringIO()
+        buffer = BytesIO()
         while sector != ENDOFCHAIN:
             buffer.write(read_sector_f(sector))
             next = read_fat_f(sector)

--- a/officeparser.py
+++ b/officeparser.py
@@ -5,6 +5,7 @@
 #             - VBA: fixed infinite loop when output file already exists
 #             - improved logging output, set default level to INFO
 
+from __future__ import print_function
 import sys
 from struct import unpack
 from optparse import OptionParser
@@ -268,7 +269,7 @@ class CompoundBinaryFile:
 
     def print_fat_sectors(self):
         for sector in self.fat_sectors:
-            print '{0:08X}'.format(sector)
+            print('{0:08X}'.format(sector))
 
     def get_stream(self, index):
         d = self.directory[index]
@@ -315,7 +316,7 @@ class Header:
         self._sectFat = self.header[18:] # sects of first 109 FAT sectors
 
     def pretty_print(self):
-        print """HEADER DUMP
+        print("""HEADER DUMP
 _abSig              = {0}
 _clid               = {1}
 _uMinorVersion      = {2}
@@ -353,11 +354,11 @@ _csectDif           = {17}""".format(
         '{0:08X}'.format(self._sectMiniFatStart),
         '{0:08X}'.format(self._csectMiniFat),
         '{0:08X}'.format(self._sectDifStart),
-        '{0:08X}'.format(self._csectDif))
+        '{0:08X}'.format(self._csectDif)))
 
         for fat in self._sectFat:
             if fat != FREESECT:
-                print '_sectFat            = {0:08X}'.format(fat)
+                print('_sectFat            = {0:08X}'.format(fat))
 
 STGTY_INVALID = 0
 STGTY_STORAGE = 1
@@ -416,7 +417,7 @@ class Directory:
         # last two bytes are padding
 
     def pretty_print(self):
-        print """
+        print("""
 _ab                 = {0}
 _cb                 = {1}
 _mse                = {2}
@@ -446,7 +447,7 @@ _dptPropType        = {13}""".format(
         '{0}'.format(self._time[1]),
         '{0:08X}'.format(self._sectStart),
         '{0:08X} ({0} bytes)'.format(self._ulSize),
-        '{0:04X}'.format(self._dptPropType))
+        '{0:04X}'.format(self._dptPropType)))
 
 def _main():
 
@@ -561,22 +562,22 @@ def _main():
 
     if options.print_directory:
         for x in xrange(0, len(ofdoc.directory)):
-            print "Directory Index {0:08X} ({0})".format(x)
+            print("Directory Index {0:08X} ({0})".format(x))
             ofdoc.directory[x].pretty_print()
-            print
+            print()
 
     if options.print_fat:
         for sector in xrange(0, len(ofdoc.fat)):
-            print '{0:08X}: {1}'.format(sector, fat_value_to_str(ofdoc.fat[sector]))
+            print('{0:08X}: {1}'.format(sector, fat_value_to_str(ofdoc.fat[sector])))
 
     if options.print_mini_fat:
         for sector in xrange(0, len(ofdoc.minifat)):
-            print '{0:08X}: {1}'.format(sector, fat_value_to_str(ofdoc.minifat[sector]))
+            print('{0:08X}: {1}'.format(sector, fat_value_to_str(ofdoc.minifat[sector])))
 
     if options.print_streams:
         for d in ofdoc.directory:
             if d._mse == STGTY_STREAM:
-                print '{0}: {1}'.format(d.index, d.name)
+                print('{0}: {1}'.format(d.index, d.name))
 
     if options.print_expected_file_size:
         expected_file_size = (len([x for x in ofdoc.fat if x != FREESECT]) * ofdoc.sector_size) + 512
@@ -584,8 +585,8 @@ def _main():
         size_diff = abs(expected_file_size - actual_file_size)
         percent_diff = (float(size_diff) / float(expected_file_size)) * 100.0
 
-        print "expected file size {0} actual {1} difference {2} ({3:0.2f}%)".format(
-            expected_file_size, actual_file_size, size_diff, percent_diff)
+        print("expected file size {0} actual {1} difference {2} ({3:0.2f}%)".format(
+            expected_file_size, actual_file_size, size_diff, percent_diff))
 
     #
     # analysis options
@@ -620,7 +621,7 @@ def _main():
                     logging.warning('invalid FAT sector reference {0:08X}'.format(value))
 
     if options.print_invalid_fat_count:
-        print "invalid FAT sector references: {0}".format(invalid_fat_sectors)
+        print("invalid FAT sector references: {0}".format(invalid_fat_sectors))
 
     invalid_fat_entries = 0
     if options.check_fat or options.print_invalid_fat_count:
@@ -634,7 +635,7 @@ def _main():
                     logging.warning('invalid FAT sector {0:08X} value {1:08X}'.format(value, ptr))
 
     if options.print_invalid_fat_count:
-        print "invalid FAT entries: {0}".format(invalid_fat_entries)
+        print("invalid FAT entries: {0}".format(invalid_fat_entries))
 
     if options.check_orphaned_chains:
         buffer = [False for fat in ofdoc.fat]

--- a/officeparser.py
+++ b/officeparser.py
@@ -801,8 +801,8 @@ def _main():
                 f.write(ofdoc.get_stream(d.index))
                 f.close()
                 if options.create_manifest:
-                    manifest.write(os.path.basename(filename))
-                    manifest.write("\n")
+                    manifest.write(os.path.basename(filename).encode())
+                    manifest.write(b"\n")
                 logging.debug("created file {0}".format(filename))
 
     while options.extract_macros:


### PR DESCRIPTION
Hello.

I am trying o make this tool Python 3 compatible while keeping backward compatibility with Python 2.7. I've tested my work with three scenarios and one testing Word document. I am not a user of this tool so I just compared the output for Python 2 and 3 and it seems to be okay.

Tested commands:
```
officeparser.py --create-manifest --extract-streams test/test.doc
officeparser.py --dump-stream-by-name=WordDocument test/test.doc
officeparser.py --print-streams test/test.doc
```

If you find something missing, please provide a reproducer (shell command) so I can use it to test my work and backward compatibility.